### PR TITLE
update dropuidgid test gid

### DIFF
--- a/tinyssh-tests/dropuidgidtest.c
+++ b/tinyssh-tests/dropuidgidtest.c
@@ -12,7 +12,7 @@ Public domain.
 static void droproot(void) {
 
     if (geteuid() == 0) {
-        if (!dropuidgid(0, 123000, 123000)) _exit(111);
+        if (!dropuidgid(0, 1230, 1230)) _exit(111);
     }
     if (geteuid() == 0) _exit(111);
 }
@@ -20,7 +20,7 @@ static void droproot(void) {
 
 static void test1(void) {
     droproot();
-    if (dropuidgid(0, 123001, getegid())) _exit(111);
+    if (dropuidgid(0, 1231, getegid())) _exit(111);
     _exit(0);
 }
 


### PR DESCRIPTION
This should fix #22 , by using a UID/GID smaller than the cap of 65535 imposed by standard user namespace configs