### PR TITLE
Option to enable unrestricted access and to spawn a custom process instead of shell

### DIFF
--- a/man/tinysshd.8
+++ b/man/tinysshd.8
@@ -61,6 +61,15 @@ don't use syslog, use standard error output (default)
 .B \-x \fIname=command
 add subsystem command (e.g.: sftp=/usr/libexec/openssh/sftp\-server)
 .TP
+.B \-e \fIcommand
+execute the given command instead of spawning the shell (disables \fIexec\fR channel requests)
+.TP
+.B \-u
+enable unrestricted access - no authentication is needed
+.TP
+.B \-U
+disable unrestricted access - authentication is needed (default)
+.TP
 .I keydir
 directory containing TinySSH keys, typically /etc/tinyssh/sshkeydir
 .SH AUTHORIZATION

--- a/tinyssh/packet.h
+++ b/tinyssh/packet.h
@@ -104,6 +104,8 @@ extern int packet_kex_receive(void);
 extern int packet_kexdh(const char *, struct buf *, struct buf *);
 
 /* packet_auth.c */
+extern int flagunrestricted;
+extern const char *executecommand;
 extern int packet_auth(struct buf *, struct buf *);
 
 /* packet_channel_open.c */

--- a/tinyssh/packet_auth.c
+++ b/tinyssh/packet_auth.c
@@ -70,7 +70,7 @@ int packet_auth(struct buf *b, struct buf *b2) {
 
         if (str_equaln((char *)b->buf + pos - len, len, "none")) {
             pkname = "none";
-            goto authorized;
+            if (flagunrestricted) goto authorized;
         }
         if (str_equaln((char *)b->buf + pos - len, len, "password")) pkname = "password";
         if (str_equaln((char *)b->buf + pos - len, len, "hostbased")) pkname = "hostbased";

--- a/tinyssh/packet_auth.c
+++ b/tinyssh/packet_auth.c
@@ -68,7 +68,10 @@ int packet_auth(struct buf *b, struct buf *b2) {
         pos = packetparser_uint32(b->buf, b->len, pos, &len);       /* publickey/password/hostbased/none */
         pos = packetparser_skip(b->buf, b->len, pos, len);
 
-        if (str_equaln((char *)b->buf + pos - len, len, "none")) pkname = "none";
+        if (str_equaln((char *)b->buf + pos - len, len, "none")) {
+            pkname = "none";
+            goto authorized;
+        }
         if (str_equaln((char *)b->buf + pos - len, len, "password")) pkname = "password";
         if (str_equaln((char *)b->buf + pos - len, len, "hostbased")) pkname = "hostbased";
         if (str_equaln((char *)b->buf + pos - len, len, "publickey")) {

--- a/tinyssh/packet_channel_request.c
+++ b/tinyssh/packet_channel_request.c
@@ -48,6 +48,11 @@ int packet_channel_request(struct buf *b1, struct buf *b2) {
         buf_putnum8(b1, 0);
         p1[plen1] = 0;
 
+        if (executecommand) {
+            log_d3("packet=SSH_MSG_CHANNEL_REQUEST, exec ", p1, ", rejected");
+            goto reject;
+        }
+
         if (!channel_exec(p1)) bug();
         log_d3("packet=SSH_MSG_CHANNEL_REQUEST, exec ", p1, ", accepted");
         goto accept;
@@ -90,7 +95,7 @@ int packet_channel_request(struct buf *b1, struct buf *b2) {
 
         pos = packetparser_end(b1->buf, b1->len, pos);
 
-        if (!channel_exec(0)) bug();
+        if (!channel_exec(executecommand)) bug();
         log_d1("packet=SSH_MSG_CHANNEL_REQUEST, shell, accepted");
         goto accept;
     }

--- a/tinyssh/tinysshd.c
+++ b/tinyssh/tinysshd.c
@@ -32,6 +32,8 @@ static unsigned int cryptotypeselected = sshcrypto_TYPENEWCRYPTO;
 static int flagverbose = 1;
 static int fdwd;
 static int flaglogger = 0;
+int flagunrestricted = 0;
+const char *executecommand = 0;
 
 static struct buf b1 = {global_bspace1, 0, sizeof global_bspace1};
 static struct buf b2 = {global_bspace2, 0, sizeof global_bspace2};
@@ -89,9 +91,15 @@ int main(int argc, char **argv) {
             if (*x == 'P') { cryptotypeselected &= ~sshcrypto_TYPEPQCRYPTO; continue; }
             if (*x == 'l') { flaglogger = 1; continue; }
             if (*x == 'L') { flaglogger = 0; continue; }
+            if (*x == 'u') { flagunrestricted = 1; continue; }
+            if (*x == 'U') { flagunrestricted = 0; continue; }
             if (*x == 'x') {
                 if (x[1]) { channel_subsystem_add(x + 1); break; }
                 if (argv[1]) { channel_subsystem_add(*++argv); break; }
+            }
+            if (*x == 'e') {
+                if (x[1]) { executecommand = x + 1; break; }
+                if (argv[1]) { executecommand = *++argv; break; }
             }
 
             die_usage(USAGE);


### PR DESCRIPTION
In the spirit of `websockify` and `tcpserver`, I have added functionality to `tinysshd` that allows secure connections to a public TCP server (a [MUD](https://en.wikipedia.org/wiki/MUD), for example). If the public server does not implement its own application layer security and only has support for the telnet protocol then providing that much needed security would be really simple thanks to `tinysshd`. 

A couple of new command line parameters were added to `tinysshd`. They are also documented in the manual:
```
 -e command
        execute the given command instead of spawning the shell (disables exec channel requests)

 -u     enable unrestricted access - no authentication is needed

 -U     disable unrestricted access - authentication is needed (default)
```

The most expected use case for this added functionality could be illustrated with the below example:
`tcpserver -HRDl0 0.0.0.0 4022 ./tinysshd -u -e 'nc localhost 4000' ./tinyssh-keys`

MUDs still use the completely insecure telnet protocol (execute `telnet stonia.ttu.ee 4000`, for example). You will see that it asks sensitive information such as the password to be sent over a plaintext channel. With the help of the proposed features [a lot of MUDs](http://www.mudconnect.com/) could be made more secure without having to change a single line in their codebase. Thanks to the fact that tinyssh is so light weight the integration would go real smoothly just like adding websocket support to a plaintext server with the help of `websockify`.