### PR TITLE
Make cross compile accessible in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 compile: make-tinyssh.sh
 	sh -e make-tinyssh.sh
+cross-compile: make-tinysshcc.sh
+	sh -e make-tinysshcc.sh
 clean:
 	rm -rf build
 install:


### PR DESCRIPTION
I am working on a buildroot project and decided to use tinyssh for remote access. Easiest is to build tinyssh by calling make but the cross compile script is not integrated in Makefile yet. This preq fixes this.