### PR TITLE
fix: MSG_USERAUTH_SUCCESS should be alone without extra bits

### DIFF
--- a/tinyssh/packet_auth.c
+++ b/tinyssh/packet_auth.c
@@ -155,7 +155,6 @@ authorized:
     log_i7("auth: ", packet.name, ": ", pkname, " ", (char *)b->buf, " accepted");
     buf_purge(b);
     buf_putnum8(b, SSH_MSG_USERAUTH_SUCCESS);
-    buf_putstring(b,"ssh-connection");
     packet_put(b);
     if (!packet_sendall()) bug();
 


### PR DESCRIPTION
Hi,

I use tinyssh to unlock LUKS fully encrypted system remotely. I tried to use asyncssh ([https://github.com/ronf/asyncssh](https://github.com/ronf/asyncssh)) to automatically input the cipher passphrase from a password store, but I had a error from asyncssh even with user authentication success from tinyssh.

From a discussion with asyncssh maintainer ([https://groups.google.com/forum/#!topic/asyncssh-users/5IxCDmbTqZc](https://groups.google.com/forum/#!topic/asyncssh-users/5IxCDmbTqZc)), `buf_putstring(b,"ssh-connection");` should be removed given RFC 4252.

For now, I remove the checking part in asyncssh in my computer and the unlocking tool is working. But, I think it should be in tinyssh.

Do you agree with this modification ?

Thanks,
Mehdi

Credit for this modification go to Ron Frederick :).