### PR TITLE
Bugfix: fix compilation with musl and clang

### DIFF
--- a/sysdep/haslogintty.h-yes.c
+++ b/sysdep/haslogintty.h-yes.c
@@ -1,6 +1,4 @@
 /* Public domain. */
-extern int login_tty(int);
-
 static void foo(void) {
     login_tty(0);
 }

--- a/sysdep/hasopenpty.h-yes.c
+++ b/sysdep/hasopenpty.h-yes.c
@@ -3,8 +3,6 @@
 #include <termios.h>
 #include <sys/ioctl.h>
 
-extern int openpty(int *, int *, char *, struct termios *, struct winsize *);
-
 static void foo(void) {
     int master, slave;
     openpty(&master, &slave, 0, 0, 0);

--- a/sysdep/hasutmploginlogout.h-yes.c
+++ b/sysdep/hasutmploginlogout.h-yes.c
@@ -3,9 +3,6 @@
 #include <sys/time.h>
 #include <utmp.h>
 
-extern void login(const struct utmp *);
-extern int logout(const char *);
-
 static void foo(void) {
     struct utmp ut = {0};
     login(&ut);

--- a/sysdep/hasutmplogwtmp.h-yes.c
+++ b/sysdep/hasutmplogwtmp.h-yes.c
@@ -1,7 +1,5 @@
 /* Public domain. */
 
-extern void logwtmp(const char *, const char *, const char *);
-
 static void foo(void) {
     logwtmp("", "", "");
 }


### PR DESCRIPTION
Also needs a `-Werror=implicit-function-declaration` in the CFLAGS as for some reason
the linker seems to accept it at configure/detection time but not
compile time.