### PR TITLE
Instruct Systemd to accept status code 111 as a successful exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
                EnvironmentFile=-/etc/default/tinysshd
                ExecStart=/usr/sbin/tinysshd ${TINYSSHDOPTS} -- /etc/tinyssh/sshkeydir
                KillMode=process
+               SuccessExitStatus=111
                StandardInput=socket
                StandardError=journal
 

--- a/man/tinysshd.8
+++ b/man/tinysshd.8
@@ -133,6 +133,7 @@ ExecStartPre=\-/usr/sbin/tinysshd\-makekey \-q /etc/tinyssh/sshkeydir
 EnvironmentFile=\-/etc/default/tinysshd
 ExecStart=/usr/sbin/tinysshd ${TINYSSHDOPTS} \-\- /etc/tinyssh/sshkeydir
 KillMode=process
+SuccessExitStatus=111
 StandardInput=socket
 StandardError=journal
 


### PR DESCRIPTION
I recommend adding `SuccessExitStatus=111` so that Systemd accepts status code 111 as a successful exit. Otherwise the `tinyssh` unit will be marked as *failed* by systemd after the first failed authentication. This happens very soon after the public server is started.