### PR TITLE
Small build system and utmp fixes

### DIFF
--- a/make-tinyssh.sh
+++ b/make-tinyssh.sh
@@ -120,7 +120,7 @@ if [ x"${LIBS}" != x ]; then
     for i in ${LIBS}; do
       echo 'int main(void) { return 0; }' > try.c
       ${compiler} ${i} -o try try.c || { log2 "${i} failed"; continue; }
-      syslibs="${i} ${syslibs}"
+      syslibs="${syslibs} ${i}"
       log2 "${i} ok"
     done
     echo ${syslibs} > syslibs
@@ -171,8 +171,8 @@ cp -pr crypto/* "${work}"
 log2 "libtinysshcrypto.a ok"
 log1 "finishing"
 
-origlibs="${origlibs} ${lib}/libtinysshcrypto.a"
-libs="${libs} ${lib}/libtinysshcrypto.a"
+origlibs="${lib}/libtinysshcrypto.a ${origlibs}"
+libs="${lib}/libtinysshcrypto.a ${libs}"
 
 log1 "starting crypto headers"
 rm -rf "${work}"

--- a/tinyssh/logsys.c
+++ b/tinyssh/logsys.c
@@ -69,15 +69,20 @@ static void logsys_utmpx(const char *user, const char *host, const char *name, l
     str_copyn(ut.ut_line, sizeof ut.ut_line, name);
 
     /* host */
-    str_copyn(ut.ut_host, sizeof ut.ut_host, host);
+    if (flaglogin)
+      str_copyn(ut.ut_host, sizeof ut.ut_host, host);
+    else
+      byte_zero(ut.ut_host, sizeof ut.ut_host);
 #ifdef HASUTMPXSYSLEN
     ut.ut_syslen = str_len(ut.ut_host) + 1;
 #endif
 
     /* user */
-    str_copyn(ut.ut_user, sizeof ut.ut_user, user);
+    if (flaglogin)
+      str_copyn(ut.ut_user, sizeof ut.ut_user, user);
+    else
+      byte_zero(ut.ut_user, sizeof ut.ut_user);
 
-    /* time */
     gettimeofday(&tv, 0);
     ut.ut_tv.tv_sec = tv.tv_sec;
     ut.ut_tv.tv_usec = tv.tv_usec;
@@ -96,8 +101,12 @@ static void logsys_utmpx(const char *user, const char *host, const char *name, l
     endutxent();
 
     /* update wtmpx */
-#if defined(_PATH_WTMPX) && defined(HASUTMPXUPDWTMPX)
+#ifdef HASUTMPXUPDWTMPX
+#if defined(_PATH_WTMPX)
     updwtmpx(_PATH_WTMPX, &ut);
+#elif defined (WTMPX_FILE)
+    updwtmpx(WTMPX_FILE, &ut);
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
This MR
- Makes using the LIBS environment variable more intuitive by not reversing the library order, and fixes resolution when symbols defined in libtinysshcrypto conflict with symbols provided in external libraries
- Makes utmpx work in more cases.

These changes were needed to make tinyssh build against utmps, a secure utmp library to use with the musl libc.

Additionally, I had to manually comment the utmp-related `-yes` sysdep definitions in `sysdep/list`. It would be nice to have a way to override sysdep detection with some manual input that does not involve editing a file. :-)