### PR TITLE
More utmp stuff! Fill utmp(x)'s ut_addr_v6 field when it exists

### DIFF
--- a/sysdep/hasutmpaddrv6.h-yes.c
+++ b/sysdep/hasutmpaddrv6.h-yes.c
@@ -1,0 +1,11 @@
+/* Public domain. */
+#include <time.h>
+#include <sys/time.h>
+#include <utmp.h>
+
+int main(void) {
+
+    struct utmp ut;
+    if (sizeof ut.ut_addr_v6 < 16) return 111;
+    return 0;
+}

--- a/sysdep/hasutmpaddrv6.h-yes.out
+++ b/sysdep/hasutmpaddrv6.h-yes.out
@@ -1,0 +1,1 @@
+#define HASUTMPADDRV6 1

--- a/sysdep/hasutmpxaddrv6.h-yes.c
+++ b/sysdep/hasutmpxaddrv6.h-yes.c
@@ -1,0 +1,11 @@
+/* Public domain. */
+#include <time.h>
+#include <sys/time.h>
+#include <utmpx.h>
+
+int main(void) {
+
+    struct utmpx utx;
+    if (sizeof utx.ut_addr_v6 < 16) return 111;
+    return 0;
+}

--- a/sysdep/hasutmpxaddrv6.h-yes.out
+++ b/sysdep/hasutmpxaddrv6.h-yes.out
@@ -1,0 +1,1 @@
+#define HASUTMPXADDRV6 1

--- a/sysdep/list
+++ b/sysdep/list
@@ -27,6 +27,8 @@ echo 'hasutmpxupdwtmpx.h hasutmpxupdwtmpx.h-yes'
 echo 'hasutmpxupdwtmpx.h default.h-no'
 echo 'hasutmpxsyslen.h hasutmpxsyslen.h-yes'
 echo 'hasutmpxsyslen.h default.h-no'
+echo 'hasutmpxaddrv6.h hasutmpxaddrv6.h-yes'
+echo 'hasutmpxaddrv6.h default.h-no'
 
 #utmp
 echo 'hasutmp.h hasutmp.h-yes'
@@ -49,6 +51,8 @@ echo 'hasutmplogwtmp.h hasutmplogwtmp.h-yes'
 echo 'hasutmplogwtmp.h default.h-no'
 echo 'hasutmploginlogout.h hasutmploginlogout.h-yes'
 echo 'hasutmploginlogout.h default.h-no'
+echo 'hasutmpaddrv6.h hasutmpaddrv6.h-yes'
+echo 'hasutmpaddrv6.h default.h-no'
 
 #limits
 echo 'haslimits.h haslimits.h-yes'

--- a/tinyssh/logsys.c
+++ b/tinyssh/logsys.c
@@ -23,6 +23,7 @@ SunOS 5.11
 #include <time.h>
 #include <sys/time.h>
 #include <paths.h>
+#include <arpa/inet.h>
 
 #include "hasutilh.h"
 #ifdef HASUTILH
@@ -35,6 +36,7 @@ SunOS 5.11
 #endif
 #include "hasutmpxupdwtmpx.h"
 #include "hasutmpxsyslen.h"
+#include "hasutmpxaddrv6.h"
 
 #include "hasutmp.h"
 #ifdef HASUTMP
@@ -49,6 +51,7 @@ SunOS 5.11
 #include "hasutmpuser.h"
 #include "hasutmplogwtmp.h"
 #include "hasutmploginlogout.h"
+#include "hasutmpaddrv6.h"
 
 #include "str.h"
 #include "byte.h"
@@ -75,6 +78,11 @@ static void logsys_utmpx(const char *user, const char *host, const char *name, l
       byte_zero(ut.ut_host, sizeof ut.ut_host);
 #ifdef HASUTMPXSYSLEN
     ut.ut_syslen = str_len(ut.ut_host) + 1;
+#endif
+
+#ifdef HASUTMPXADDRV6
+    if (inet_pton(AF_INET6, ut.ut_host, &ut.ut_addr_v6) <= 0)
+      inet_pton(AF_INET, ut.ut_host, &ut.ut_addr_v6[0]) ;
 #endif
 
     /* user */
@@ -129,6 +137,10 @@ static void logsys_utmp(const char *user, const char *host, const char *name, lo
     /* host */
 #ifdef HASUTMPHOST
     str_copyn(ut.ut_host, sizeof ut.ut_host, host);
+# ifdef HASUTMPADDRV6
+    if (inet_pton(AF_INET6, ut.ut_host, &ut.ut_addr_v6) <= 0)
+      inet_pton(AF_INET, ut.ut_host, &ut.ut_addr_v6[0]) ;
+# endif
 #endif
 
     /* user */


### PR DESCRIPTION
openssh (and soon dropbear as well, when I upstream my patches) fills the ut_addr_v6 field of the utmp(x) structure with the remote IP of the ssh client. This patch makes tinyssh do the same.

- Add sysdeps to test the existence of ut_addr_v6 in utmp and utmpx (it's not a standard field, but it exists at least on Linux)
- We already have the remote IP as a string, we just add a decoding step in logsys_utmp(x) to fill the addr field.
- We assume arpa/inet.h and AF_INET6 exist on the system. If the build fails on some systems (those would be *ancient*), sysdeps will need to be added to test for them.