### PR TITLE
sysdep: Reference the test code from main

### DIFF
--- a/sysdep/haslogintty.h-yes.c
+++ b/sysdep/haslogintty.h-yes.c
@@ -5,6 +5,8 @@ static void foo(void) {
     login_tty(0);
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (!argc)
+        foo();
     return 0;
 }

--- a/sysdep/hasopenpty.h-yes.c
+++ b/sysdep/hasopenpty.h-yes.c
@@ -10,6 +10,8 @@ static void foo(void) {
     openpty(&master, &slave, 0, 0, 0);
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (!argc)
+        foo();
     return 0;
 }

--- a/sysdep/hasutmploginlogout.h-yes.c
+++ b/sysdep/hasutmploginlogout.h-yes.c
@@ -12,6 +12,8 @@ static void foo(void) {
     logout(ut.ut_line);
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (!argc)
+      foo();
     return 0;
 }

--- a/sysdep/hasutmplogwtmp.h-yes.c
+++ b/sysdep/hasutmplogwtmp.h-yes.c
@@ -6,6 +6,8 @@ static void foo(void) {
     logwtmp("", "", "");
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (!argc)
+        foo();
     return 0;
 }

--- a/sysdep/hasutmpx.h-yes.c
+++ b/sysdep/hasutmpx.h-yes.c
@@ -15,6 +15,8 @@ static void foo(void) {
     endutxent();
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (!argc)
+        foo();
     return 0;
 }

--- a/sysdep/hasutmpxupdwtmpx.h-yes.c
+++ b/sysdep/hasutmpxupdwtmpx.h-yes.c
@@ -6,6 +6,8 @@ static void foo(void) {
     updwtmpx("/nonexistent", &ut);
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+    if (!argc)
+        foo();
     return 0;
 }


### PR DESCRIPTION
With lld 14 and no additional LDFLAGS the referenced foo()-function was optimized out, as an executable was compiled with no reference to the function, also removing the undefined references to the tested libc functions.

This caused the sysdep mechanism to misdetect hasutmploginlogout.h-yes.c and sysdep/hasutmplogwtmp.h-yes.c on musl libc as true, while it should be false, which broke the build later on on the real references in tinyssh code.

This can also be reproduced with gcc with CFLAGS=-ffunction-sections and LDFLAGS=-Wl,--gc-sections.

Instead reference them, but do not evaluate them at runtime by making the prequisite argc == 0. This should be safe from being optimized out even with LTO.