### PR TITLE
implementation kex-strict-s-v00@openssh.com

### DIFF
--- a/tinyssh/packet_get.c
+++ b/tinyssh/packet_get.c
@@ -83,8 +83,17 @@ int packet_get(struct buf *b, crypto_uint8 x) {
             return 0;
         case SSH_MSG_IGNORE:
         case SSH_MSG_DEBUG:
+            if (!packet.flagkeys) {
+                log_f1("SSH_MSG_IGNORE/SSH_MSG_DEBUG packet rejected in plain-text mode");
+                global_die(111);
+            }
             buf_purge(b);
             break;
+        case SSH_MSG_NEWKEYS:
+            /* strict kex - reset receivepacketid */
+            if (sshcrypto_kex_flags & sshcrypto_FLAGSTRICTKEX) {
+                packet.receivepacketid = 0;
+            }
         default:
             if (x && x != b->buf[0]) {
                 char buf1[NUMTOSTR_LEN];

--- a/tinyssh/packet_get.c
+++ b/tinyssh/packet_get.c
@@ -63,6 +63,12 @@ static int packet_get_(struct buf *b) {
     else {
         return packet_get_plain_(b);
     }
+
+    /* overflow check */
+    if (!packet.receivepacketid) {
+        log_f1("receivepacketid overflow");
+        global_die(111);
+    }
 }
 
 

--- a/tinyssh/packet_kexdh.c
+++ b/tinyssh/packet_kexdh.c
@@ -91,6 +91,7 @@ int packet_kexdh(const char *keydir, struct buf *b1, struct buf *b2) {
         if (!packet_getall(b2, 0)) return 0;
     } while (b2->buf[0] != SSH_MSG_NEWKEYS);
 
+
     /* key derivation */
     for(i = 0; i < 6; ++i) {
         buf_purge(b1);

--- a/tinyssh/packet_put.c
+++ b/tinyssh/packet_put.c
@@ -8,6 +8,7 @@ Public domain.
 #include "buf.h"
 #include "sshcrypto.h"
 #include "ssh.h"
+#include "log.h"
 #include "packet.h"
 
 static void packet_put_plain_(struct buf *b) {
@@ -44,6 +45,12 @@ void packet_put(struct buf *b) {
     }
     else {
         packet_put_plain_(b);
+    }
+
+    /* overflow check */
+    if (!packet.sendpacketid) {
+        log_f1("sendpacketid overflow");
+        global_die(111);
     }
 
     /* strict kex - reset sendpacketid */

--- a/tinyssh/packet_put.c
+++ b/tinyssh/packet_put.c
@@ -6,6 +6,8 @@ Public domain.
 
 #include "uint32_pack_big.h"
 #include "buf.h"
+#include "sshcrypto.h"
+#include "ssh.h"
 #include "packet.h"
 
 static void packet_put_plain_(struct buf *b) {
@@ -42,5 +44,10 @@ void packet_put(struct buf *b) {
     }
     else {
         packet_put_plain_(b);
+    }
+
+    /* strict kex - reset sendpacketid */
+    if (b->buf[0] == SSH_MSG_NEWKEYS && sshcrypto_kex_flags & sshcrypto_FLAGSTRICTKEX) {
+        packet.sendpacketid = 0;
     }
 }

--- a/tinyssh/sshcrypto.h
+++ b/tinyssh/sshcrypto.h
@@ -15,6 +15,8 @@
 #define sshcrypto_kem_MAX           crypto_kem_sntrup761x25519_BYTES
 #define sshcrypto_hash_MAX          crypto_hash_sha512_BYTES
 
+#define sshcrypto_FLAGSTRICTKEX 0x1
+
 struct sshcrypto_kex {
     const char *name;
     int (*enc)(unsigned char *, unsigned char *, const unsigned char *);
@@ -29,6 +31,14 @@ struct sshcrypto_kex {
 };
 extern struct sshcrypto_kex sshcrypto_kexs[];
 
+struct sshcrypto_pseudokex {
+    const char *name;
+    const char *cname;
+    int flag;
+};
+extern struct sshcrypto_pseudokex sshcrypto_pseudokexs[];
+
+extern int sshcrypto_kex_flags;
 extern const char *sshcrypto_kex_name;
 extern int (*sshcrypto_enc)(unsigned char *, unsigned char *, const unsigned char *);
 extern long long sshcrypto_kem_publickeybytes;

--- a/tinyssh/tinysshd.exp
+++ b/tinyssh/tinysshd.exp
@@ -16,7 +16,7 @@
 
 --- tinysshd default setup
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -25,7 +25,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -osp
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -34,7 +34,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -s -p
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -43,7 +43,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -osP
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -52,7 +52,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -s -P
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -61,7 +61,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -oSp
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -70,7 +70,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -S -p
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -79,7 +79,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -oSP
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -88,7 +88,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -S -P
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -97,7 +97,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -Osp
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -106,7 +106,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -s -p
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -115,7 +115,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OsP
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -124,7 +124,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -s -P
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -133,7 +133,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OSp
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -142,7 +142,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -S -p
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -151,7 +151,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OSP
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -160,7 +160,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -S -P
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -169,7 +169,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -osp, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -178,7 +178,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -s -p, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -187,7 +187,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -osP, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -196,7 +196,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -s -P, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -205,7 +205,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -oSp, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -214,7 +214,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -S -p, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -223,7 +223,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -oSP, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -232,7 +232,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -S -P, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -241,7 +241,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -Osp, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -250,7 +250,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -s -p, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -259,7 +259,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OsP, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -268,7 +268,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -s -P, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms: ssh-ed25519 
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -277,7 +277,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OSp, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -286,7 +286,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -S -p, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -295,7 +295,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OSP, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -304,7 +304,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -S -P, ecdsa-sha2-nistp256 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -313,7 +313,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -osp, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -322,7 +322,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -s -p, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -331,7 +331,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -osP, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -340,7 +340,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -s -P, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -349,7 +349,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -oSp, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -358,7 +358,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -S -p, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -367,7 +367,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -oSP, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -376,7 +376,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -o -S -P, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -385,7 +385,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -Osp, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -394,7 +394,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -s -p, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -403,7 +403,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OsP, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -412,7 +412,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -s -P, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org 
+_tinysshd-printkex: info: kex algorithms: curve25519-sha256,curve25519-sha256@libssh.org,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -421,7 +421,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OSp, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -430,7 +430,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -S -p, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com 
+_tinysshd-printkex: info: kex algorithms: sntrup761x25519-sha512@openssh.com,kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server: chacha20-poly1305@openssh.com 
 _tinysshd-printkex: info: encryption algorithms server to client: chacha20-poly1305@openssh.com 
@@ -439,7 +439,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -OSP, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  
@@ -448,7 +448,7 @@ _tinysshd-printkex: info: mac algorithms server to client: hmac-sha2-256
 
 --- tinysshd recognizes -O -S -P, ssh-ed25519 key missing
 
-_tinysshd-printkex: info: kex algorithms:  
+_tinysshd-printkex: info: kex algorithms: kex-strict-s-v00@openssh.com 
 _tinysshd-printkex: info: server host key algorithms:  
 _tinysshd-printkex: info: encryption algorithms client to server:  
 _tinysshd-printkex: info: encryption algorithms server to client:  


### PR DESCRIPTION
Add new KEX kex-strict-s-v00@openssh.com protocol.
'Terrapin Attack'  mitigation CVE-2023-48795.
Fixes https://github.com/janmojzis/tinyssh/issues/81
