### PR TITLE
packet_put: Add missing bug.h include for global_die

### DIFF
--- a/tinyssh/packet_put.c
+++ b/tinyssh/packet_put.c
@@ -6,6 +6,7 @@ Public domain.
 
 #include "uint32_pack_big.h"
 #include "buf.h"
+#include "bug.h"
 #include "sshcrypto.h"
 #include "ssh.h"
 #include "log.h"


### PR DESCRIPTION
```
packet_put.c:53:9: error: call to undeclared function 'global_die'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        global_die(111);
        ^
1 error generated.
```
