### PR TITLE
README.md: fix systemd variable substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo make install
                [Service]
                ExecStartPre=-/usr/sbin/tinysshd-makekey -q /etc/tinyssh/sshkeydir
                EnvironmentFile=-/etc/default/tinysshd
-               ExecStart=/usr/sbin/tinysshd ${TINYSSHDOPTS} -- /etc/tinyssh/sshkeydir
+               ExecStart=/usr/sbin/tinysshd $TINYSSHDOPTS -- /etc/tinyssh/sshkeydir
                KillMode=process
                SuccessExitStatus=111
                StandardInput=socket


### PR DESCRIPTION
In systemd.service, ${VAR} treats the content as a single argument. This causes tinysshd to fail when multiple options are provided (e.g., -x sftp=/usr/lib/openssh/sftp-server -v).Switching to $VAR enables word splitting, passing each option as a separate argument as required by the tinysshd parser.